### PR TITLE
Letterspacing

### DIFF
--- a/main.css
+++ b/main.css
@@ -101,17 +101,15 @@ h6 {
 
 @keyframes header {
   0% {
-    letter-spacing: 2rem;
+    letter-spacing: 0.2em;
   }
 
   25% {
-    letter-spacing: 5rem;
+    letter-spacing: 0.5em;
   }
 
-
-
   90%{
-    letter-spacing: -1rem;
+    letter-spacing: -0.1em;
   }
 }
 


### PR DESCRIPTION
Wenn du ein Letter-spacing in CSS angibst, dann würde ich dies immer relativ zur Schriftgrösse (em) angeben. So kannst du die Schrift vergrössern und verkleiner und das spacing bleibt sich gleich. Dies ist das verhalten, was du auch aus den Grafik-Programmen kennst. Da ist es ja auch so, dass wenn du die Schrift grösser oder kleiner machst, das Spacing gleich bleibt (relativ zur Schriftgrösse). Warum Safari und Chrome deine Definitinon von `rem` ander interpretieren ist aber eine gute Frage... 🤷‍♂️